### PR TITLE
[chore]: add workflow to lint and test python code

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,16 +28,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         # Enter directory with Python server code before checking for requirements.txt
-        if [ -d server ]; then cd server; fi
+        if [ -d server ]; then cd chitchat_server; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        if [ -d server ]; then cd server; fi
+        if [ -d server ]; then cd chitchat_server; fi
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        if [ -d server ]; then cd server; fi
+        if [ -d server ]; then cd chitchat_server; fi
         pytest


### PR DESCRIPTION
Added workflow to lint and test python code in the `server` directory using flake8 and pytest on Python 3.11.